### PR TITLE
fix(deps): add packaging requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setuptools.setup(
     install_requires=(
         "google-api-core[grpc] >= 1.22.2, < 2.0.0dev",
         "proto-plus >= 1.10.0",
+        "packaging >= 14.3"
     ),
     python_requires=">=3.6",
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setuptools.setup(
     install_requires=(
         "google-api-core[grpc] >= 1.22.2, < 2.0.0dev",
         "proto-plus >= 1.10.0",
-        "packaging >= 14.3"
+        "packaging >= 14.3",
     ),
     python_requires=">=3.6",
     classifiers=[

--- a/testing/constraints-3.6.txt
+++ b/testing/constraints-3.6.txt
@@ -21,3 +21,4 @@
 # Then this file should have foo==1.14.0
 google-api-core==1.22.2
 proto-plus==1.10.0
+packaging==14.3


### PR DESCRIPTION
Add packaging requirement. packaging.version
              is used for a version comparison in transports/base.py