### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "orgpolicy",
     "name_pretty": "Organization Policy",
     "product_documentation": "https://cloud.google.com/resource-manager/docs/organization-policy/overview",
-    "client_documentation": "https://googleapis.dev/python/orgpolicy/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/orgpolicy/latest",
     "issue_tracker": "",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ resources across the Cloud Resource Hierarchy.
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-org-policy.svg
    :target: https://pypi.org/project/google-cloud-org-policy/
 .. _Organization Policy: https://cloud.google.com/resource-manager/docs/organization-policy/overview
-.. _Client Library Documentation: https://googleapis.dev/python/orgpolicy/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/orgpolicy/latest
 .. _Product Documentation:  https://cloud.google.com/resource-manager/docs/organization-policy/overview
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.